### PR TITLE
Feat: add support for dressing.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,54 @@ vim.keymap.set("n", "<leader>rn", function()
 end, { expr = true })
 ```
 
+<details>
+  <summary style="font-size: 14pt">&#127800; <code>dressing.nvim</code> support</summary>
+
+</br>If your are using [dressing.nvim](https://github.com/stevearc/dressing.nvim)
+or a similar plugin that uses a separate buffer for typing the new name,
+you can call the `rename` function that `inc-rename` provides:
+```lua
+require("inc_rename").rename(opts | nil)
+
+-- To prefill the word under the cursor, pass a default value:
+require("inc_rename").rename({ default = vim.fn.expand("<cword>") })
+```
+
+This function calls `vim.ui.input()` with the optional default input (which `dressing.nvim` hijacks)
+and manages the highlighting in a more manual way (that means highlighting does not rely on Neovim's
+command-preview feature).
+> :warning: Note that highlighting will not work with the builtin `vim.ui.input` function
+> because it is currently not possible to modify the buffer while the user is still typing
+> in the command line.
+
+The result should look something like this:
+<div align="center">
+<img src="https://user-images.githubusercontent.com/40792180/175773326-df2b6f92-9865-4fea-a08b-cbe89e5dd1b0.png">
+</div>
+</br>
+
+> :bulb: Tip - try these `dressing.nvim` settings to position the input box above the
+> cursor to not cover the word being renamed (thank you
+> [@RaafatTurki](https://github.com/RaafatTurki) for the suggestion!):
+```lua
+require("dressing").setup {
+  input = {
+    override = function(conf)
+      conf.col = -1
+      conf.row = 0
+      return conf
+    end,
+  },
+}
+```
+
+</details>
 
 ## Customization
 You can override the default settings by passing a Lua table to the `setup` function.
 The default options are:
 ```lua
-require("inc_rename.nvim").setup {
+require("inc_rename").setup {
   cmd_name = "IncRename", -- the name of the command
   hl_group = "Substitute", -- the highlight group used for highlighting the identifier's new name
   multifile_preview = true, -- whether to enable the command preview across multiple buffers

--- a/lua/inc_rename/init.lua
+++ b/lua/inc_rename/init.lua
@@ -39,7 +39,7 @@ local single_file_strategy = {
       -- E.g. sumneko_lua sends ranges across multiple lines when a table value is a function, skip this range.
       if range.start.line == range["end"].line then
         local line_nr = range.start.line
-        local line = vim.api.nvim_buf_get_lines(0, line_nr, line_nr + 1, false)[1]
+        local line = vim.api.nvim_buf_get_lines(bufnr, line_nr, line_nr + 1, false)[1]
         local start_col, end_col = range.start.character, range["end"].character
         local line_item = { text = line, start_col = start_col, end_col = end_col }
         -- Same line was already seen
@@ -63,8 +63,20 @@ local single_file_strategy = {
       apply_highlights_fn(0, line_nr, line_info)
     end
   end,
-  restore_buffer_state = function(_)
-    state.should_fetch_references = true
+  restore_buffer_state = function(should_fetch_references, opts)
+    opts = opts or {}
+    -- Only clear highlights when bufnr is explicitly passed, if not passed
+    -- buffer will be cleared by command preview automatically
+    if opts.bufnr and state.cached_lines then
+      vim.api.nvim_buf_clear_namespace(opts.bufnr, opts.preview_ns, 0, -1)
+      for line_nr, line_info in pairs(state.cached_lines) do
+        for _, inter_line_info in ipairs(line_info) do
+          vim.api.nvim_buf_set_lines(opts.bufnr, line_nr, line_nr + 1, true, { inter_line_info.text })
+        end
+      end
+    end
+    state.cached_lines = nil
+    state.should_fetch_references = should_fetch_references
   end,
 }
 
@@ -73,7 +85,7 @@ local multi_file_strategy = {
     local cached_lines = {}
     for _, res in ipairs(result) do
       local range = res.range
-      -- E.g. sumneko_lua sends ranges across multiple lines when a table value is a function, skip this range.
+      -- E.g. sumneko_lua sends ranges across multiple lines when a table value is a function, skip this range
       if range.start.line == range["end"].line then
         local bufnr = vim.uri_to_bufnr(res.uri)
         -- Only need to highlight loaded buffers
@@ -112,13 +124,15 @@ local multi_file_strategy = {
       end
     end
   end,
-  restore_buffer_state = function(cached_lines)
-    if cached_lines then
-      local cur_bufnr = vim.api.nvim_get_current_buf()
+  restore_buffer_state = function(should_fetch_references, opts)
+    if state.cached_lines then
+      opts = opts or {}
+      local cur_bufnr = opts.bufnr or vim.api.nvim_get_current_buf()
       -- Reset highlights and buffer lines
-      for bufnr, line_info_per_bufnr in pairs(cached_lines) do
-        if bufnr ~= cur_bufnr then
-          vim.api.nvim_buf_clear_namespace(bufnr, state.preview_ns, 0, -1)
+      for bufnr, line_info_per_bufnr in pairs(state.cached_lines) do
+        -- Clear highlights when buffer is explicitly passed
+        if cur_bufnr or bufnr ~= cur_bufnr then
+          vim.api.nvim_buf_clear_namespace(bufnr, opts.preview_ns or state.preview_ns, 0, -1)
           for line_nr, line_info in pairs(line_info_per_bufnr) do
             for _, inter_line_info in ipairs(line_info) do
               vim.api.nvim_buf_set_lines(bufnr, line_nr, line_nr + 1, true, { inter_line_info.text })
@@ -126,13 +140,14 @@ local multi_file_strategy = {
           end
         end
       end
+      state.cached_lines = nil
     end
-    state.should_fetch_references = true
+    state.should_fetch_references = should_fetch_references
   end,
 }
 
 -- Get positions of LSP reference symbols
-local function fetch_lsp_references(bufnr)
+local function fetch_lsp_references(bufnr, lsp_params)
   local clients = vim.lsp.get_active_clients {
     bufnr = bufnr,
   }
@@ -145,7 +160,7 @@ local function fetch_lsp_references(bufnr)
     return
   end
 
-  local params = vim.lsp.util.make_position_params()
+  local params = lsp_params or vim.lsp.util.make_position_params()
   params.context = { includeDeclaration = true }
   vim.lsp.buf_request(bufnr, "textDocument/references", params, function(err, result, _, _)
     if err then
@@ -191,7 +206,7 @@ local function incremental_rename_preview(opts, preview_ns, preview_buf)
   if state.should_fetch_references then
     state.should_fetch_references = false
     state.err = nil
-    fetch_lsp_references(vim.api.nvim_get_current_buf())
+    fetch_lsp_references(opts.bufnr or vim.api.nvim_get_current_buf(), opts.lsp_params)
     return
   end
 
@@ -202,10 +217,6 @@ local function incremental_rename_preview(opts, preview_ns, preview_buf)
   end
 
   local new_name = opts.args
-  -- Ignore whitespace-only name (abort highlighting)
-  if new_name:match("^%s*$") then
-    return
-  end
 
   local function apply_highlights_fn(bufnr, line_nr, line_info)
     local offset = 0
@@ -225,13 +236,20 @@ local function incremental_rename_preview(opts, preview_ns, preview_buf)
       offset = offset + #new_name - (info.end_col - info.start_col)
     end
 
-    vim.api.nvim_buf_set_lines(bufnr, line_nr, line_nr + 1, false, { updated_line })
+    vim.api.nvim_buf_set_lines(bufnr or opts.bufnr, line_nr, line_nr + 1, false, { updated_line })
     if preview_buf then
       vim.api.nvim_buf_set_lines(preview_buf, line_nr, line_nr + 1, false, { updated_line })
     end
 
     for _, hl_pos in ipairs(highlight_positions) do
-      vim.api.nvim_buf_add_highlight(bufnr, preview_ns, M.config.hl_group, line_nr, hl_pos.start_col, hl_pos.end_col)
+      vim.api.nvim_buf_add_highlight(
+        bufnr or opts.bufnr,
+        preview_ns,
+        M.config.hl_group,
+        line_nr,
+        hl_pos.start_col,
+        hl_pos.end_col
+      )
       if preview_buf then
         vim.api.nvim_buf_add_highlight(
           preview_buf,
@@ -293,33 +311,60 @@ local function perform_lsp_rename(new_name)
 end
 
 -- Called when the command is executed (user pressed enter)
-local function incremental_rename_execute(opts)
-  -- Any errors that occur in the preview function are not directly shown to the user but are stored in vim.v.errmsg.
-  -- For more info, see https://github.com/neovim/neovim/issues/18910.
-  if vim.v.errmsg ~= "" then
-    vim.notify(
-      "[inc-rename] An error occurred in the preview function. Please report this error here: https://github.com/smjonas/inc-rename.nvim/issues:\n"
-        .. vim.v.errmsg,
-      vim.lsp.log_levels.ERROR
-    )
-  elseif state.err then
-    vim.notify(state.err.msg, state.err.level)
-  else
-    perform_lsp_rename(opts.args)
-  end
-  state.should_fetch_references = true
+local function incremental_rename_execute(new_name)
+  -- Schedule wrapping here avoids an (uncommon) issue where buffer contents were
+  -- changed by the highlight function after the rename request had already been executed.
+  -- (Probably because synchronous LSP requests are not queued like Nvim API calls?)
+  vim.schedule(function()
+    -- Any errors that occur in the preview function are not directly shown to the user but are stored in vim.v.errmsg.
+    -- For more info, see https://github.com/neovim/neovim/issues/18910.
+    if vim.v.errmsg ~= "" then
+      vim.notify(
+        "[inc-rename] An error occurred in the preview function. Please report this error here: https://github.com/smjonas/inc-rename.nvim/issues:\n"
+          .. vim.v.errmsg,
+        vim.lsp.log_levels.ERROR
+      )
+    elseif state.err then
+      vim.notify(state.err.msg, state.err.level)
+    else
+      perform_lsp_rename(new_name)
+    end
+  end)
+end
+
+-- This function can be used when using a plugin like dressing.nvim
+-- (or more generally, when the new name is typed in a separate buffer).
+-- That means highlighting is not available with the default vim.ui.input().
+M.rename = function(opts)
+  vim.validate {
+    ["[inc_rename] rename function arguments"] = { opts, "table", true },
+  }
+  opts = opts or {}
+  local ns = vim.api.nvim_create_namespace("inc_rename")
+  local bufnr = vim.api.nvim_get_current_buf()
+  local lsp_params = vim.lsp.util.make_position_params()
+
+  vim.ui.input({
+    prompt = "New name: ",
+    default = opts.default,
+    -- Misuse highlight function as callback
+    highlight = function(new_name)
+      incremental_rename_preview({ args = new_name, bufnr = bufnr, lsp_params = lsp_params }, ns, nil)
+      return {}
+    end,
+  }, function(new_name)
+    state.preview_strategy.restore_buffer_state(true, { bufnr = bufnr, preview_ns = ns })
+    if new_name ~= nil then
+      incremental_rename_execute(new_name)
+    end
+  end)
 end
 
 local create_user_command = function(cmd_name)
-  -- Create the user command
-  vim.api.nvim_create_user_command(
-    cmd_name,
-    -- Schedule wrapping here avoids an (uncommon) issue where buffer contents were
-    -- changed by the highlight function after the rename request had already been executed.
-    -- (Probably because synchronous LSP requests are not queued like Nvim API calls?)
-    vim.schedule_wrap(incremental_rename_execute),
-    { nargs = 1, addr = "lines", preview = incremental_rename_preview }
-  )
+  vim.api.nvim_create_user_command(cmd_name, function(opts)
+    state.preview_strategy.restore_buffer_state(true)
+    incremental_rename_execute(opts.args)
+  end, { nargs = 1, addr = "lines", preview = incremental_rename_preview })
 end
 
 M.setup = function(user_config)
@@ -333,7 +378,7 @@ M.setup = function(user_config)
     group = id,
     callback = vim.schedule_wrap(function()
       if not state.should_fetch_references then
-        state.preview_strategy.restore_buffer_state(state.cached_lines)
+        state.preview_strategy.restore_buffer_state(true, { restore_text = true })
       end
     end),
   })


### PR DESCRIPTION
Hey @RaafatTurki , I have added support for `dressing.nvim`! Could you please help me test out this PR before I merge it? I want to make sure I didn't break anything. You can use it by specifiying the `dressing_support` branch in your package manager.

To use this feature, you simply have to call `:lua require("inc_rename").rename()` while `dressing.nvim` is installed (or any other plugin that uses a separate buffer for entering the new name).