### PR TITLE
refactor!: remove multifile_strategy (this is now supported by Neovim natively)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ require("inc_rename").setup {
   cmd_name = "IncRename", -- the name of the command
   hl_group = "Substitute", -- the highlight group used for highlighting the identifier's new name
   preview_empty_name = false, -- whether an empty new name should be previewed; if false the command preview will be cancelled instead
-  multifile_preview = true, -- whether to enable the command preview across multiple buffers
   show_message = true, -- whether to display a `Renamed m instances in n files` message after a rename operation
   post_hook = nil, -- callback to run after renaming, receives the result table (from LSP handler) as an argument
 }


### PR DESCRIPTION
Highlights across multiple buffers are now cleared by Neovim automatically so providing a separate multifile option is no longer necessary: https://github.com/neovim/neovim/pull/19360

Will be merged in four weeks from now (September 16) once tested and people have had a chance to upgrade their nightly version. 