### PR TITLE
fix: handle `change.edits` being `nil`

### DIFF
--- a/lua/inc_rename/init.lua
+++ b/lua/inc_rename/init.lua
@@ -491,7 +491,7 @@ local function show_success_message(result)
 
   local with_edits = result.documentChanges ~= nil
   for _, change in pairs(result.documentChanges or result.changes) do
-    changed_instances = changed_instances + (with_edits and #change.edits or #change)
+    changed_instances = changed_instances + (with_edits and #(change.edits or {}) or #change)
     changed_files = changed_files + 1
   end
 


### PR DESCRIPTION
LSPs will respond to `textDocument/rename` requests with a [`WorkSpaceEdit`][1] response, whose `documentChanges` field may not always contain objects with an `edits` field. This commit handles the cases where the latter is `nil`.

[1]: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceEdit

Closes #69.