### PR TITLE
set title to "Rename" when using snacks

### DIFF
--- a/lua/inc_rename/init.lua
+++ b/lua/inc_rename/init.lua
@@ -80,6 +80,7 @@ local snacks_config = {
     ---@type snacks.win|nil
     local snacks_win = vim.ui.input({ default = default }, function() end)
     if snacks_win then
+      snacks_win:set_title("Rename", "left")
       state.input_bufnr = snacks_win.buf
       state.input_win_id = snacks_win.win
     end


### PR DESCRIPTION
It seems to just say "Input" when using `snacks.nvim`. This line changes that to "Rename" instead.

<img width="947" height="482" alt="image" src="https://github.com/user-attachments/assets/fbc4c4ba-4609-4c09-b419-3d756eac6b86" />


It also sets title alignment since the function requires setting that param... but this is personal preference and should probably be passed in as a config instead?. On that note, maybe the title should also be user config for the plugin?.

I feel like maybe setting some window styles for the snacks.input window should be configurable in the extension as well 🤔. Right now I set this using the main styles config for _all_ snacks.input windows (code below).

This might be of interest to https://github.com/smjonas/inc-rename.nvim/issues/48 as well, since the config i have kinda tries to do a vscode-like renaming using this plugin + snacks.input.

It might also be of interest to have window config to avoid something like i've seen here: https://github.com/folke/snacks.nvim/issues/1670#issuecomment-2863746751 (setting autocommands that dynamically set and reset those main styles )

# current setup

Currently this change above + the config below here works pretty well! 🎉 I get a nice renaming input box that's positioned at the cursor this way. (would be cool to have the input be smaller and grow as the text of the input is entered... but that's not at all important 😅... I couldn't find a way to make snacks.input do that easily)

My snacks.input `styles` block config:
```lua
styles = {
  input = {
    relative = "cursor",
    row = -3,
    col = -2
  }
},
```

also seems to work best with the following:
```
vim.opt.splitright = true
vim.opt.splitbelow = true
vim.opt.splitkeep = "topline" -- affects snacks.input relative due to the preview buffer resizing the main window
```