### PR TITLE
fix: use client:supports_method() for Neovim 0.11+

### DIFF
--- a/lua/inc_rename/utils.lua
+++ b/lua/inc_rename/utils.lua
@@ -16,6 +16,10 @@ M.get_active_clients = function(bufnr, method)
     return clients
   end
   clients = vim.tbl_filter(function(client)
+    if vim.fn.has("nvim-0.11") == 1 then
+      return client:supports_method(method)
+    end
+    ---@diagnostic disable-next-line: deprecated
     return client.supports_method(method)
   end, clients)
   return clients


### PR DESCRIPTION
## Summary
- Fixes the deprecation warning: `client.supports_method is deprecated. Feature will be removed in Nvim 0.13`
- Uses the method-style `client:supports_method(method)` on Neovim 0.11+ while keeping the old dot-notation call for older versions
- Follows the same backwards-compatibility pattern already used elsewhere in the codebase (e.g. `make_client_position_params`, `client:request`)

## Test plan
- [x] Verify no deprecation warning on Neovim 0.11+
- [ ] Verify rename still works on Neovim < 0.11