### PR TITLE
fix: handle string return from handle_references in error path

### DIFF
--- a/lua/inc_rename/init.lua
+++ b/lua/inc_rename/init.lua
@@ -208,8 +208,8 @@ local function fetch_lsp_references(bufnr, lsp_params)
 
     -- Only call set_error and exit when all clients have been exhausted
     if client_response_counter == #clients then
-      if handle_references_result.err then
-        set_error(handle_references_result.err, vim.lsp.log_levels.WARN)
+      if type(handle_references_result) == "string" then
+        set_error(handle_references_result, vim.lsp.log_levels.WARN)
       end
       -- Leave command line mode when there is nothing to rename.
       api.nvim_feedkeys(ctrl_c, "n", false)

--- a/lua/inc_rename/init.lua
+++ b/lua/inc_rename/init.lua
@@ -195,7 +195,7 @@ local function fetch_lsp_references(bufnr, lsp_params)
       return
     end
 
-    local ok, handle_references_result = utils.handle_references(clients, err, result, ctx)
+    local ok, handle_references_error = utils.handle_references(clients, err, result, ctx)
     if ok then
       handle_references_success = true
       state.cached_line_infos_per_bufnr = filter_duplicates(cache_lines(result))
@@ -208,8 +208,8 @@ local function fetch_lsp_references(bufnr, lsp_params)
 
     -- Only call set_error and exit when all clients have been exhausted
     if client_response_counter == #clients then
-      if type(handle_references_result) == "string" then
-        set_error(handle_references_result, vim.lsp.log_levels.WARN)
+      if handle_references_error ~= nil then
+        set_error(handle_references_error, vim.lsp.log_levels.WARN)
       end
       -- Leave command line mode when there is nothing to rename.
       api.nvim_feedkeys(ctrl_c, "n", false)


### PR DESCRIPTION
## Summary

`utils.handle_references` is typed as `@return boolean, string?` and all its return paths confirm this — it returns a plain string as the second value, never a table with an `.err` property.

Line 211 indexed `handle_references_result.err` which:
- **Crashes** when the value is `nil` (attempt to index a nil value)
- **Silently produces nil** when the value is a string (strings don't have an `.err` field), meaning the error message was never actually displayed

## Fix

Check `type(handle_references_result) == "string"` and pass the string directly to `set_error`.

## Error

```
Error executing vim.schedule lua callback: .../share/nvim/lazy/inc-rename.nvim/lua/inc_rename/init.lua:211: in...
stack traceback:
  .../share/nvim/lazy/inc-rename.nvim/lua/inc_rename/init.lua:211: in...
  .../neovim/0.11.6/share/nvim/runtime/lua/vim/lsp/client.lua:682: in...
  vim/_editor.lua: in function <vim/_editor.lua:0>
```

Reproduced with `vtsls` on Neovim 0.11.6. The error occurs when opening the rename input — the crash inadvertently prevented `feedkeys(ctrl_c)` from executing, so the rename itself still worked despite the error.

## Test plan

- [x] Verified rename works in TypeScript files (vtsls) without error
- [x] Verified rename continues to work in Kotlin files (unaffected)