### PR TITLE
fix: only count relevant client responses in reference exhaustion check

### DIFF
--- a/lua/inc_rename/init.lua
+++ b/lua/inc_rename/init.lua
@@ -189,7 +189,6 @@ local function fetch_lsp_references(bufnr, lsp_params)
   local client_response_counter = 0
   local handle_references_success = false
   vim.lsp.buf_request(bufnr, "textDocument/references", params, function(err, result, ctx, config)
-    client_response_counter = client_response_counter + 1
     if handle_references_success then
       -- A request has already succeeded, ignore other results.
       return
@@ -206,11 +205,15 @@ local function fetch_lsp_references(bufnr, lsp_params)
       return
     end
 
+    -- Only count responses from clients in our filtered list;
+    -- handle_references returns nil as the second value for unrecognized clients
+    if handle_references_result ~= nil then
+      client_response_counter = client_response_counter + 1
+    end
+
     -- Only call set_error and exit when all clients have been exhausted
     if client_response_counter == #clients then
-      if handle_references_result.err then
-        set_error(handle_references_result.err, vim.lsp.log_levels.WARN)
-      end
+      set_error(handle_references_result, vim.lsp.log_levels.WARN)
       -- Leave command line mode when there is nothing to rename.
       api.nvim_feedkeys(ctrl_c, "n", false)
       return


### PR DESCRIPTION
**NOTE: This includes the changes from #94 which should be merged first**

## Summary

`fetch_lsp_references` filters clients by `textDocument/rename` capability (line 177), but `vim.lsp.buf_request` sends `textDocument/references` to **all** clients attached to the buffer (line 191). The callback fires for every client, but `handle_references` returns `(false, nil)` for clients not in the filtered list.

Previously, `client_response_counter` was incremented for every callback including unrecognized clients. This caused the counter to reach `#clients` prematurely — before the actual rename-capable client had responded — triggering an early exit from command mode via `feedkeys(ctrl_c)`.

## Fix

Move the counter increment after the `handle_references` call and only count responses where `handle_references_result ~= nil`, meaning the client was actually in the filtered list. This ensures the exhaustion check only considers relevant clients.

## Test plan

- [ ] Verify rename works when multiple LSP clients are attached (e.g. vtsls + eslint) and only some support rename
- [ ] Verify rename still exits command mode when all relevant clients fail